### PR TITLE
添加标签条件判断

### DIFF
--- a/src/items.js
+++ b/src/items.js
@@ -45,10 +45,10 @@ export default {
           isCondition = item.hasTag(_tag)
         }
       }
-      if (operation === "add" && !item.hasTag(tags[i])) {
+      if (operation === "add" && !item.hasTag(tags[i]) && isCondition) {
         item.addTag(tags[i], userTag ? 0 : 1);
         updateCount += 1;
-      } else if (operation === "remove" && item.hasTag(tags[i])) {
+      } else if (operation === "remove" && item.hasTag(tags[i]) && isCondition) {
         item.removeTag(tags[i]);
         updateCount += 1;
       } else if (operation === "change") {

--- a/src/items.js
+++ b/src/items.js
@@ -33,17 +33,16 @@ export default {
     Zotero.debug(operation, tags);
     let updateCount = 0;
     for (let i = 0; i < tags.length; ++i) {
-      // For '/open[!/read]', add '/open' tag under the condition item doesn't contain '/read' tag.
-      const regex = /(.+)\[(.+)\]/
-      let isCondition = true
-      if (tags[i].search(regex) != -1) {
-        let [_, tag, _tag] = tags[i].match(regex)
-        tags[i] = tag
-        if (_tag.startsWith("!")) {
-          isCondition = !item.hasTag(_tag.slice(1))
-        } else {
-          isCondition = item.hasTag(_tag)
-        }
+      const expTagRegex = /^('|"|`)(.+)\[(.+)\]\1$/;
+      let isCondition = true;
+      if (expTagRegex.test(tags[i])) {
+          let [tag, condition_tag] = tags[i].match(expTagRegex).slice(2);
+          tags[i] = tag;
+          if (condition_tag.startsWith("!")) {
+            isCondition = !item.hasTag(condition_tag.slice(1));
+          } else {
+            isCondition = item.hasTag(condition_tag);
+          }
       }
       if (operation === "add" && !item.hasTag(tags[i]) && isCondition) {
         item.addTag(tags[i], userTag ? 0 : 1);
@@ -51,7 +50,7 @@ export default {
       } else if (operation === "remove" && item.hasTag(tags[i]) && isCondition) {
         item.removeTag(tags[i]);
         updateCount += 1;
-      } else if (operation === "change") {
+      } else if (operation === "change" && isCondition) {
         if (item.hasTag(tags[i])) {
           item.removeTag(tags[i]);
         } else {

--- a/src/items.js
+++ b/src/items.js
@@ -33,6 +33,19 @@ export default {
     Zotero.debug(operation, tags);
     let updateCount = 0;
     for (let i = 0; i < tags.length; ++i) {
+      // For '/open[!/read]', add '/open' tag under the condition item doesn't contain '/read' tag.
+      // Text only, no emoticon support
+      const regex = /(.+)\[(.+)\]/
+      let isCondition = true
+      if (tags[i].search(regex) != -1) {
+        let [_, tag, _tag] = tags[i].match(regex)
+        tags[i] = tag
+        if (_tag.startsWith("!")) {
+          isCondition = !item.hasTag(_tag.slice(1))
+        } else {
+          isCondition = item.hasTag(_tag)
+        }
+      }
       if (operation === "add" && !item.hasTag(tags[i])) {
         item.addTag(tags[i], userTag ? 0 : 1);
         updateCount += 1;

--- a/src/items.js
+++ b/src/items.js
@@ -34,7 +34,6 @@ export default {
     let updateCount = 0;
     for (let i = 0; i < tags.length; ++i) {
       // For '/open[!/read]', add '/open' tag under the condition item doesn't contain '/read' tag.
-      // Text only, no emoticon support
       const regex = /(.+)\[(.+)\]/
       let isCondition = true
       if (tags[i].search(regex) != -1) {


### PR DESCRIPTION
应用场景：某些配置下，item被标记/read后，再次被打开，可能会再次被标记/open。现在设置/open[!/read]表示在/read不存在时添加标签，没有"!"表示在有/read的情况下添加。
![image](https://user-images.githubusercontent.com/51939531/202853147-01a3de13-06f4-4fa2-81f6-a8439b2f6375.png)